### PR TITLE
Added mod struct handling back in

### DIFF
--- a/code/client/item.c
+++ b/code/client/item.c
@@ -18,6 +18,12 @@ uint32_t item_mod_arg2(uint32_t mod)
     return (mod & 0x000000FF);
 }
 
+void free_item(Item *item)
+{
+    array_reset(&item->mod_struct);
+    free(item);
+}
+
 void remove_item_from_bag(Item *item)
 {
     if (!item->bag) return;
@@ -129,6 +135,12 @@ void HandleItemGeneralInfo(Connection *conn, size_t psize, Packet *packet)
     new_item->value = pack->value;
     kstr_read(&new_item->name, pack->name, ARRAY_SIZE(pack->name));
 
+    array_init(&new_item->mod_struct);
+    array_resize(&new_item->mod_struct, pack->n_modifier);
+    for(size_t i=0;i<pack->n_modifier;i++) {
+        array_set(&new_item->mod_struct, i, pack->modifier[i]);
+    }
+
     // @Cleanup: Save modifier
 
     array_set(items, pack->item_id, new_item);
@@ -157,7 +169,7 @@ void HandleItemRemove(Connection *conn, size_t psize, Packet *packet)
 
     array_set(items, pack->item_id, NULL);
     remove_item_from_bag(item);
-    free(item);
+    free_item(item);
 }
 
 void HandleItemWeaponSet(Connection *conn, size_t psize, Packet *packet)

--- a/code/client/item.h
+++ b/code/client/item.h
@@ -14,7 +14,7 @@ typedef struct Item {
 
     struct kstr name;
     uint16_t    name_buffer[8];
-    uint32_t    mod_struct[12];
+    array(uint32_t) mod_struct;
 
     Bag        *bag;
     ItemType    type;
@@ -30,6 +30,7 @@ static void api_make_item(ApiItem *dest, Item *src)
     dest->type      = src->type;
 }
 
+void free_item(Item* src);
 
 void remove_item_from_bag(Item *item);
 Item *get_item_safe(GwClient *client, int32_t id);

--- a/code/client/world.c
+++ b/code/client/world.c
@@ -36,7 +36,7 @@ static void reset_world(World *world)
 {
     Item **item;
     array_foreach(item, &world->items) {
-        free(*item);
+        free_item(*item);
     }
 
     Agent **agent;

--- a/code/client/world.h
+++ b/code/client/world.h
@@ -8,6 +8,7 @@ typedef struct World {
 
     BagArray            bags;
     ArrayItem           items;
+    array(uint32_t)     item_mod_structs;
     ArrayParty          parties;
     ArrayGuild          guilds;
     ArrayQuest          quests;

--- a/include/client/Headquarter.h
+++ b/include/client/Headquarter.h
@@ -124,7 +124,7 @@ HQAPI uint32_t          GetNpcIdOfAgent(AgentId agent_id);
 HQAPI bool              GetItem(ApiItem *item, uint32_t item_id);
 HQAPI bool              GetItemOfAgent(ApiItem *item, AgentId agent_id);
 HQAPI BagEnum           GetItemLocation(uint32_t item_id, unsigned int *slot);
-HQAPI size_t            GetItemModStruct(uint32_t item_id, uint32_t *buffer, size_t length);
+HQAPI int            GetItemModStruct(uint32_t item_id, uint32_t *buffer, size_t length);
 HQAPI size_t            GetItemName(uint32_t item_id, uint16_t* buffer, size_t length);
 HQAPI size_t            GetBagCapacity(BagEnum bag);
 HQAPI size_t            GetBagItems(BagEnum bag, ApiItem *buffer, size_t length);


### PR DESCRIPTION
I'm using mod structs, was a bit confused why it wasn't working anymore after the merge - we had the API call still, but `item.c` was no longer using the mod struct.

I've made this an array, and changed `free(item)` in both places to call a function that first frees this array before freeing the parent (this is one of those rare times that I miss cpp)